### PR TITLE
支持新版DdddOCR

### DIFF
--- a/captcha.py
+++ b/captcha.py
@@ -5,8 +5,8 @@ import ddddocr
 
 app = Flask(__name__)
 
-ocr_beta = ddddocr.DdddOcr(beta=True, show_ad=False)
-ocr_old = ddddocr.DdddOcr(beta=False, show_ad=False)
+ocr_beta = ddddocr.DdddOcr(old=False, show_ad=False)
+ocr_old = ddddocr.DdddOcr(old=True, show_ad=False)
 
 @app.route('/ocr')
 @cross_origin()


### PR DESCRIPTION
如题，新版ddddocr已经把 `beta` 翻转成了 `old`。